### PR TITLE
Force strict alignment requirement

### DIFF
--- a/pb.h
+++ b/pb.h
@@ -15,7 +15,7 @@
 
 /* Define this if your CPU / compiler combination does not support
  * unaligned memory access to packed structures. */
-/* #define PB_NO_PACKED_STRUCTS 1 */
+#define PB_NO_PACKED_STRUCTS 1
 
 /* Increase the number of required fields that are tracked.
  * A compiler warning will tell if you need this. */


### PR DESCRIPTION
An issue was identified when compiling the `starling` codebase on the M1 Macbook machine. You can read over the [slack conversation](https://snav.slack.com/archives/CFDTDBASU/p1638813359005200) for more details.

`starling` PR - https://github.com/swift-nav/starling/pull/6010