### PR TITLE
Don't Look for Generator in Default Paths

### DIFF
--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -355,6 +355,7 @@ find_path(NANOPB_GENERATOR_SOURCE_DIR
     DOC "nanopb generator source"
     PATHS
     ${NANOPB_SRC_ROOT_FOLDER}/generator
+    NO_DEFAULT_PATH
     NO_CMAKE_FIND_ROOT_PATH
 )
 mark_as_advanced(NANOPB_GENERATOR_SOURCE_DIR)


### PR DESCRIPTION
When nanopb is installed as a system package, the find script
will find `nanopb_generator.py` in `/usr/bin` and set that directory as the value of `NANOPB_GENERATOR_SOURCE_DIR`.

The function `nanopb_generate_cpp` tries to copy the directory defined by `NANOPB_GENERATOR_SOURCE_DIR` into the build tree at build time, resulting in an error.

The `NO_DEFAULT_PATH` option turns off many of the implicit paths cmake searches in `find_file`, so that the one defined by the `PATHS` option is preferred. This fixes the build when nanopb is installed on the system.

I'm surprised the `extra/FindNanopb.cmake` script works so well the way we're using it, (including it at the end of `CMakeLists.txt`), considering it was just intended as an example script.