### PR TITLE
CMake fixes after repo sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@ set(nanopb_SOVERSION 0)
 
 string(REPLACE "nanopb-" "" nanopb_VERSION ${nanopb_VERSION_STRING})
 
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
-option(BUILD_STATIC_LIBS "Build static libraries" ON)
-
 option(nanopb_BUILD_RUNTIME "Build the headers and libraries needed at runtime" ON)
 option(nanopb_BUILD_GENERATOR "Build the protoc plugin for code generation" ON)
 option(nanopb_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
@@ -88,8 +85,7 @@ else()
 endif()
 
 if(nanopb_BUILD_RUNTIME)
-    if(BUILD_SHARED_LIBS)
-        add_library(protobuf-nanopb SHARED
+        add_library(protobuf-nanopb
             pb.h
             pb_common.h
             pb_common.c
@@ -107,26 +103,6 @@ if(nanopb_BUILD_RUNTIME)
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         )
-    endif()
-
-    if(BUILD_STATIC_LIBS)
-        add_library(protobuf-nanopb-static STATIC
-            pb.h
-            pb_common.h
-            pb_common.c
-            pb_encode.h
-            pb_encode.c
-            pb_decode.h
-            pb_decode.c)
-        set_target_properties(protobuf-nanopb-static PROPERTIES
-            OUTPUT_NAME protobuf-nanopb)
-        install(TARGETS protobuf-nanopb-static EXPORT nanopb-targets
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-        target_include_directories(protobuf-nanopb-static INTERFACE
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        )
-    endif()
 
     configure_file(extra/nanopb-config-version.cmake.in
         nanopb-config-version.cmake @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,3 +118,5 @@ if(nanopb_BUILD_RUNTIME)
     install(FILES pb.h pb_common.h pb_encode.h pb_decode.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
+
+include(extra/FindNanopb.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.13)
 
 project(nanopb C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,16 @@ if(nanopb_BUILD_RUNTIME)
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         )
+        # without this, the compilations fails due to C99 asserts
+        target_compile_definitions(protobuf-nanopb PUBLIC
+            PB_NO_STATIC_ASSERT
+        )
+        if(NOT MSVC)
+            # This is needed to avoid warnings about switch statements on enum types
+            target_compile_options(protobuf-nanopb PUBLIC
+                -Wno-switch-enum
+            )
+        endif()
 
     configure_file(extra/nanopb-config-version.cmake.in
         nanopb-config-version.cmake @ONLY)

--- a/extra/FindNanopb.cmake
+++ b/extra/FindNanopb.cmake
@@ -363,6 +363,7 @@ find_path(NANOPB_GENERATOR_SOURCE_DIR
     DOC "nanopb generator source"
     PATHS
     ${NANOPB_SRC_ROOT_FOLDER}/generator
+    NO_DEFAULT_PATH
     NO_CMAKE_FIND_ROOT_PATH
 )
 mark_as_advanced(NANOPB_GENERATOR_SOURCE_DIR)

--- a/pb.h
+++ b/pb.h
@@ -14,9 +14,8 @@
 /* #define PB_ENABLE_MALLOC 1 */
 
 /* Define this if your CPU / compiler combination does not support
- * unaligned memory access to packed structures. Note that packed
- * structures are only used when requested in .proto options. */
-/* #define PB_NO_PACKED_STRUCTS 1 */
+ * unaligned memory access to packed structures. */
+#define PB_NO_PACKED_STRUCTS 1
 
 /* Increase the number of required fields that are tracked.
  * A compiler warning will tell if you need this. */


### PR DESCRIPTION
After having synced this repo with nanopb/master the swift specific patches have to be applied again.
Additionally two new patches are added to suppress C99 assertion warnings and missing switch statements.