### PR TITLE
Implement MODULE and WORKSPACE compatibility using same name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "com_github_nanopb_nanopb")
+workspace(name = "nanopb")
 
 load("//extra/bazel:nanopb_deps.bzl", "nanopb_deps")
 

--- a/docs/bazel_build.md
+++ b/docs/bazel_build.md
@@ -8,21 +8,21 @@ Add the following to your WORKSPACE file.
 ``` py 
 # WORKSPACE
 git_repository(
-    name = "com_github_nanopb_nanopb",
+    name = "nanopb",
     remote = "https://github.com/nanopb/nanopb.git"
     commit = "<TODO:Enter your desired commit>",
 )
 
-load("@com_github_nanopb_nanopb//extra/bazel:nanopb_deps.bzl", "nanopb_deps")
+load("@nanopb//extra/bazel:nanopb_deps.bzl", "nanopb_deps")
 
 nanopb_deps()
 
-load("@com_github_nanopb_nanopb//extra/bazel:python_deps.bzl", 
+load("@nanopb//extra/bazel:python_deps.bzl", 
     "nanopb_python_deps")
 
 nanopb_python_deps()
 
-load("@com_github_nanopb_nanopb//extra/bazel:nanopb_workspace.bzl", 
+load("@nanopb//extra/bazel:nanopb_workspace.bzl", 
     "nanopb_workspace")
 
 nanopb_workspace()
@@ -33,7 +33,7 @@ To use the Nanopb rules with in your build you can use the
 `cc_proto_library` rule.
 ```  py
 # BUILD.bazel
-load("@com_github_nanopb_nanopb//extra/bazel:nanopb_cc_proto_library.bzl", 
+load("@nanopb//extra/bazel:nanopb_cc_proto_library.bzl", 
     "nanopb_cc_proto_library")
 
 # Your native proto_library.

--- a/extra/bazel/nanopb_cc_proto_library.bzl
+++ b/extra/bazel/nanopb_cc_proto_library.bzl
@@ -39,7 +39,7 @@ cc_nanopb_proto_compile = rule(
         _plugins = attr.label_list(
             providers = [ProtoPluginInfo],
             default = [
-                Label("@com_github_nanopb_nanopb//:nanopb_plugin"),
+                Label("@nanopb//:nanopb_plugin"),
             ],
             doc = "List of protoc plugins to apply",
         ),
@@ -94,5 +94,5 @@ def cc_nanopb_proto_library(name, **kwargs):  # buildifier: disable=function-doc
     )
 
 PROTO_DEPS = [
-    "@com_github_nanopb_nanopb//:nanopb",
+    "@nanopb//:nanopb",
 ]

--- a/extra/bazel/nanopb_deps.bzl
+++ b/extra/bazel/nanopb_deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def nanopb_deps():
     # Setup proto rules.
-    # Used by: com_github_nanopb_nanopb, rules_proto_grpc.
+    # Used by: nanopb, rules_proto_grpc.
     # Used in modules: root.
     if "rules_proto" not in native.existing_rules():
         http_archive(
@@ -16,7 +16,7 @@ def nanopb_deps():
         )
 
     # Required for plugin rules.
-    # Used by: com_github_nanopb_nanopb.
+    # Used by: nanopb.
     # Used in modules: generator.
     if "rules_python" not in native.existing_rules():
         http_archive(
@@ -27,7 +27,7 @@ def nanopb_deps():
         )
 
     # Setup grpc tools.
-    # Used by: com_github_nanopb_nanopb.
+    # Used by: nanopb.
     # Used in modules: generator/proto.
     if "rules_proto_grpc" not in native.existing_rules():
         http_archive(

--- a/extra/bazel/python_deps.bzl
+++ b/extra/bazel/python_deps.bzl
@@ -2,11 +2,11 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 
 def nanopb_python_deps(interpreter=None):
     # Required for python deps for generator plugin.
-    # Used by: com_github_nanopb_nanopb.
+    # Used by: nanopb.
     # Used in modules: generator.
     if "nanopb_pypi" not in native.existing_rules():
         pip_parse(
             name = "nanopb_pypi",
-            requirements_lock = "@com_github_nanopb_nanopb//:extra/requirements_lock.txt",
+            requirements_lock = "@nanopb//:extra/requirements_lock.txt",
             python_interpreter_target = interpreter,
         )


### PR DESCRIPTION
In order to use `@nanopb` everywhere, small adaptations have to be made. This change is needed, when consuming `nanopb` in `WORKSPACE` with the same reponame as in `MODULE`.

- [x] Tested in https://github.com/swift-nav/starling/pull/10074 for Bazel 6 and 7